### PR TITLE
[BC Break] Fixes invalid code challenge method payload key name

### DIFF
--- a/src/Grant/AuthCodeGrant.php
+++ b/src/Grant/AuthCodeGrant.php
@@ -312,14 +312,14 @@ class AuthCodeGrant extends AbstractAuthorizeGrant
             );
 
             $payload = [
-                'client_id'               => $authCode->getClient()->getIdentifier(),
-                'redirect_uri'            => $authCode->getRedirectUri(),
-                'auth_code_id'            => $authCode->getIdentifier(),
-                'scopes'                  => $authCode->getScopes(),
-                'user_id'                 => $authCode->getUserIdentifier(),
-                'expire_time'             => (new \DateTime())->add($this->authCodeTTL)->format('U'),
-                'code_challenge'          => $authorizationRequest->getCodeChallenge(),
-                'code_challenge_method  ' => $authorizationRequest->getCodeChallengeMethod(),
+                'client_id'             => $authCode->getClient()->getIdentifier(),
+                'redirect_uri'          => $authCode->getRedirectUri(),
+                'auth_code_id'          => $authCode->getIdentifier(),
+                'scopes'                => $authCode->getScopes(),
+                'user_id'               => $authCode->getUserIdentifier(),
+                'expire_time'           => (new \DateTime())->add($this->authCodeTTL)->format('U'),
+                'code_challenge'        => $authorizationRequest->getCodeChallenge(),
+                'code_challenge_method' => $authorizationRequest->getCodeChallengeMethod(),
             ];
 
             $response = new RedirectResponse();


### PR DESCRIPTION
I guess this change might be a BC break for existing and active authorization tokens when they're validated by the server. The good thing is that an authorization token has a very short expiration time and is used once to request an access token.